### PR TITLE
Add Playlist screen

### DIFF
--- a/lib/data_model/episode.dart
+++ b/lib/data_model/episode.dart
@@ -5,6 +5,7 @@ class Episode {
   final DateTime? releaseDate;
   final String imageUrl;
   final int? durationMs;
+  int? order;
   bool isPlayed;
   bool isInPlaylist;
   bool isDownloaded;
@@ -15,6 +16,7 @@ class Episode {
     required this.description,
     required this.releaseDate,
     required this.imageUrl,
+    this.order,
     this.durationMs,
     this.isPlayed = false,
     this.isInPlaylist = false,
@@ -29,6 +31,10 @@ class Episode {
       releaseDate: json['release_date'] == null ? null : DateTime.parse(json['release_date']),
       imageUrl: getCoverImage(json),
       durationMs: json['duration_ms'],
+      isPlayed: json['is_played'] ?? false,
+      isInPlaylist: json['is_in_playlist'] ?? false,
+      isDownloaded: json['is_downloaded'] ?? false,
+      order: json['order'],
     );
   }
 
@@ -60,6 +66,10 @@ class Episode {
       'release_date': _toString(releaseDate),
       'image_url': imageUrl,
       'duration_ms': durationMs,
+      'is_played': isPlayed,
+      'is_in_playlist': isInPlaylist,
+      'is_downloaded': isDownloaded,
+      'order': order,
     };
   }
 

--- a/lib/data_model/episode.dart
+++ b/lib/data_model/episode.dart
@@ -1,40 +1,73 @@
 class Episode {
   final String id;
-  final String title;
+  final String name;
   final String description;
-  final DateTime? publicationDate;
+  final DateTime? releaseDate;
   final String imageUrl;
   final int? durationMs;
   bool isPlayed;
   bool isInPlaylist;
+  bool isDownloaded;
 
   Episode({
     required this.id,
-    required this.title,
+    required this.name,
     required this.description,
-    required this.publicationDate,
+    required this.releaseDate,
     required this.imageUrl,
     this.durationMs,
     this.isPlayed = false,
     this.isInPlaylist = false,
+    this.isDownloaded = false,
   });
 
-  factory Episode.fromJson(Map<String, dynamic> json) {
+  factory Episode.fromJson(String id, Map<String, dynamic> json) {
     return Episode(
-      id: json['id'],
-      title: json['name'] ?? '',
+      id: id,
+      name: json['name'] ?? '',
       description: json['description'],
-      publicationDate: json['release_date'] == null ? null : DateTime.parse(json['release_date']),
+      releaseDate: json['release_date'] == null ? null : DateTime.parse(json['release_date']),
       imageUrl: getCoverImage(json),
       durationMs: json['duration_ms'],
     );
   }
 
+  factory Episode.fromFirestore(String id, Map<String, dynamic> data) {
+    return Episode.fromJson(id, data);
+  }
+
   static String getCoverImage(Map<String, dynamic> json) {
+    if (json['image_url'] != null) {
+      return json['image_url'];
+    }
+    
+    if (json['images'] == null) {
+      return '';
+    }
+    
     if (json['images'].isNotEmpty) {
       return json['images'][0]['url'];
     }
 
     return '';
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'release_date': _toString(releaseDate),
+      'image_url': imageUrl,
+      'duration_ms': durationMs,
+    };
+  }
+
+  String _toString(DateTime? date) {
+    if (date == null) return '';
+
+    return "${date.year.toString().padLeft(4, '0')}-"
+      "${date.month.toString().padLeft(2, '0')}-"
+      "${date.day.toString().padLeft(2, '0')}";
   }
 }

--- a/lib/feature/view/building_blocks/episode_tile.dart
+++ b/lib/feature/view/building_blocks/episode_tile.dart
@@ -22,12 +22,12 @@ class EpisodeTile extends StatelessWidget {
         fit: BoxFit.cover,
       ),
       title: Text(
-        episode.title,
+        episode.name,
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
       ),
       subtitle: Text(
-        episode.publicationDate.toString(),
+        episode.releaseDate.toString(),
         style: TextStyle(fontSize: 12),
       ),
       trailing: IconButton(

--- a/lib/feature/view/building_blocks/episode_tile.dart
+++ b/lib/feature/view/building_blocks/episode_tile.dart
@@ -6,12 +6,47 @@ import 'package:podcast/feature/view/episode_details_screen.dart';
 class EpisodeTile extends StatelessWidget {
   final Episode episode;
   final String backupImageUrl;
-  final Function(Episode episode) onToggleInPlaylist;
+  final Function(Episode episode)? onToggleInPlaylist;
 
   const EpisodeTile({super.key, required this.episode, required this.backupImageUrl, required this.onToggleInPlaylist});
 
   @override
   Widget build(BuildContext context) {
+    List<Widget> children = [];
+    if (onToggleInPlaylist != null) {
+      children.add(
+        IconButton(
+          icon: Icon(
+            episode.isInPlaylist ? Icons.playlist_add_check : Icons.playlist_add,
+            color: episode.isInPlaylist ? Colors.green : Colors.black,
+          ),
+          onPressed: () => onToggleInPlaylist!(episode),
+        ),
+      );
+    }
+    children.add(
+      IconButton(
+        icon: Icon(Icons.play_arrow),
+        onPressed: () {
+          // Handle play episode
+        },
+      ),
+    );
+    children.add(
+      IconButton(
+        icon: Icon(
+          episode.isDownloaded
+              ? Icons.download_done
+              : Icons.download,
+        ),
+        onPressed: () {
+          // setState(() {
+          //   episode.isDownloaded = !episode.isDownloaded;
+          // });
+        },
+      ),
+    );
+
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
       dense: true,
@@ -30,12 +65,9 @@ class EpisodeTile extends StatelessWidget {
         episode.releaseDate.toString(),
         style: TextStyle(fontSize: 12),
       ),
-      trailing: IconButton(
-        icon: Icon(
-          episode.isInPlaylist ? Icons.playlist_add_check : Icons.playlist_add,
-          color: episode.isInPlaylist ? Colors.green : Colors.black,
-        ),
-        onPressed: () => onToggleInPlaylist(episode),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
       ),
       onTap: () {
         // Navigate to EpisodeDetailsScreen

--- a/lib/feature/view/episode_details_screen.dart
+++ b/lib/feature/view/episode_details_screen.dart
@@ -11,7 +11,7 @@ class EpisodeDetailsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(episode.title),
+        title: Text(episode.name),
       ),
       body: SingleChildScrollView( // Wrap content in SingleChildScrollView to avoid overflow
         padding: const EdgeInsets.all(16.0),
@@ -23,12 +23,12 @@ class EpisodeDetailsScreen extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             Text(
-              episode.title,
+              episode.name,
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 10),
             Text(
-              'Release Date: ${episode.publicationDate.toString()}',
+              'Release Date: ${episode.releaseDate.toString()}',
               style: const TextStyle(fontSize: 16, color: Colors.grey),
             ),
             const SizedBox(height: 20),

--- a/lib/feature/view/latest_episodes_screen.dart
+++ b/lib/feature/view/latest_episodes_screen.dart
@@ -56,11 +56,11 @@ class LatestEpisodesScreenState extends State<LatestEpisodesScreen> {
 
       setState(() {
         episodes.sort((a, b) {
-          if (a.publicationDate == null && b.publicationDate == null) return 0;
-          if (a.publicationDate == null) return -1;
-          if (b.publicationDate == null) return 1;
+          if (a.releaseDate == null && b.releaseDate == null) return 0;
+          if (a.releaseDate == null) return -1;
+          if (b.releaseDate == null) return 1;
           
-          return b.publicationDate!.compareTo(a.publicationDate!);
+          return b.releaseDate!.compareTo(a.releaseDate!);
         });
 
         _episodes = episodes;
@@ -89,9 +89,9 @@ class LatestEpisodesScreenState extends State<LatestEpisodesScreen> {
     episodeData['items'].forEach((item) {
       result.add(Episode(
         id: item['id'],
-        title: item['name'],
+        name: item['name'],
         description: item['description'],
-        publicationDate: DateTime.parse(item['release_date']),
+        releaseDate: DateTime.parse(item['release_date']),
         imageUrl: item['images'][0]['url'],
       ));
     });
@@ -139,9 +139,7 @@ class LatestEpisodesScreenState extends State<LatestEpisodesScreen> {
     });
 
     if (episode.isInPlaylist) {
-      await playlistRef.set({
-        'title': episode.title,
-      });
+      await playlistRef.set(episode.toJson());
     } else {
       await playlistRef.delete();
     }

--- a/lib/feature/view/latest_episodes_screen.dart
+++ b/lib/feature/view/latest_episodes_screen.dart
@@ -115,6 +115,7 @@ class LatestEpisodesScreenState extends State<LatestEpisodesScreen> {
         .collection('users')
         .doc(userId)
         .collection('playlist')
+        .orderBy('order')
         .get();
 
     final playlistEpisodeIds = playlistSnapshot.docs.map((doc) => doc.id).toSet();
@@ -127,22 +128,31 @@ class LatestEpisodesScreenState extends State<LatestEpisodesScreen> {
   }
 
   Future<void> _toggleInPlaylist(Episode episode) async {
-    final userId = _currentUser!.uid;
+    final userId = _auth.currentUser!.uid;
+
     final playlistRef = _firestore
         .collection('users')
         .doc(userId)
-        .collection('playlist')
-        .doc(episode.id);
-
-    setState(() {
-      episode.isInPlaylist = !episode.isInPlaylist;
-    });
+        .collection('playlist');
 
     if (episode.isInPlaylist) {
-      await playlistRef.set(episode.toJson());
+      // Remove from playlist
+      await playlistRef.doc(episode.id).delete();
+      episode.isInPlaylist = false;
     } else {
-      await playlistRef.delete();
+      // Fetch current max order number
+      final querySnapshot = await playlistRef.orderBy('order', descending: true).limit(1).get();
+      int maxOrder = querySnapshot.docs.isNotEmpty ? querySnapshot.docs.first['order'] as int : 0;
+
+      // Add to playlist with next order number
+      episode.isInPlaylist = true;
+      episode.order = maxOrder + 1;
+      await playlistRef.doc(episode.id).set(episode.toJson());
     }
+
+    setState(() {
+      episode.isInPlaylist = episode.isInPlaylist;
+    });
   }
 
   @override

--- a/lib/feature/view/playlist_screen.dart
+++ b/lib/feature/view/playlist_screen.dart
@@ -1,0 +1,196 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+
+import 'package:podcast/data_model/episode.dart';
+import 'package:podcast/feature/view/building_blocks/episode_tile.dart';
+
+class PlaylistScreen extends StatefulWidget {
+  const PlaylistScreen({super.key});
+
+  @override
+  PlaylistScreenState createState() => PlaylistScreenState();
+}
+
+class PlaylistScreenState extends State<PlaylistScreen> {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  List<Episode> _playlist = [];
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchPlaylist();
+  }
+
+  Future<void> _fetchPlaylist() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    final currentUser = _auth.currentUser;
+    if (currentUser == null) return;
+
+    final playlistSnapshot = await _firestore
+        .collection('users')
+        .doc(currentUser.uid)
+        .collection('playlist')
+        .get();
+
+    final playedSnapshot = await _firestore
+        .collection('users')
+        .doc(currentUser.uid)
+        .collection('episodesCompleted')
+        .get();
+
+    final playedEpisodeIds = playedSnapshot.docs.map((doc) => doc.id).toSet();
+
+    List<Episode> playlist = [];
+    for (var doc in playlistSnapshot.docs) {
+      if (!playedEpisodeIds.contains(doc.id)) {
+        playlist.add(Episode.fromFirestore(doc.id, doc.data()));
+      }
+    }
+
+    setState(() {
+      _playlist = playlist;
+      _isLoading = false;
+    });
+  }
+
+  void _reorderPlaylist(int oldIndex, int newIndex) {
+    setState(() {
+      if (newIndex > oldIndex) newIndex -= 1;
+      final item = _playlist.removeAt(oldIndex);
+      _playlist.insert(newIndex, item);
+    });
+    _updatePlaylistOrderInFirestore();
+  }
+
+  Future<void> _updatePlaylistOrderInFirestore() async {
+    final currentUser = _auth.currentUser;
+    if (currentUser == null) return;
+
+    final playlistRef = _firestore
+        .collection('users')
+        .doc(currentUser.uid)
+        .collection('playlist');
+
+    for (int i = 0; i < _playlist.length; i++) {
+      await playlistRef.doc(_playlist[i].id).update({'order': i});
+    }
+  }
+
+  Future<void> _removeFromPlaylist(Episode episode) async {
+    final currentUser = _auth.currentUser;
+    if (currentUser == null) return;
+
+    await _firestore
+        .collection('users')
+        .doc(currentUser.uid)
+        .collection('playlist')
+        .doc(episode.id)
+        .delete();
+
+    setState(() {
+      _playlist.remove(episode);
+    });
+  }
+
+  Future<void> _markAsPlayed(Episode episode) async {
+    final currentUser = _auth.currentUser;
+    if (currentUser == null) return;
+
+    await _firestore
+        .collection('users')
+        .doc(currentUser.uid)
+        .collection('episodesCompleted')
+        .doc(episode.id)
+        .set({'played': true});
+
+    _removeFromPlaylist(episode);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Playlist')),
+      body: _isLoading
+          ? Center(child: CircularProgressIndicator())
+          : ReorderableListView(
+              onReorder: _reorderPlaylist,
+              children: _playlist
+                  .map(
+                    (episode) => Slidable(
+                      key: ValueKey(episode.id),
+                      endActionPane: ActionPane(
+                        motion: ScrollMotion(),
+                        children: [
+                          SlidableAction(
+                            onPressed: (context) => _removeFromPlaylist(episode),
+                            backgroundColor: Colors.red,
+                            foregroundColor: Colors.white,
+                            icon: Icons.delete,
+                            label: 'Remove',
+                          ),
+                          SlidableAction(
+                            onPressed: (context) => _markAsPlayed(episode),
+                            backgroundColor: Colors.green,
+                            foregroundColor: Colors.white,
+                            icon: Icons.check,
+                            label: 'Mark Played',
+                          ),
+                        ],
+                      ),
+                      child: EpisodeTile(episode: episode, backupImageUrl: '', onToggleInPlaylist: (_){}),
+                      
+                      // ListTile(
+                      //   leading: Image.network(
+                      //     episode.imageUrl,
+                      //     height: 60,
+                      //     width: 60,
+                      //     fit: BoxFit.cover,
+                      //   ),
+                      //   title: Text(
+                      //     episode.name,
+                      //     maxLines: 2,
+                      //     overflow: TextOverflow.ellipsis,
+                      //   ),
+                      //   subtitle: Text(
+                      //     episode.releaseDate.toString(),
+                      //     style: TextStyle(fontSize: 12),
+                      //   ),
+                      //   trailing: Row(
+                      //     mainAxisSize: MainAxisSize.min,
+                      //     children: [
+                      //       IconButton(
+                      //         icon: Icon(Icons.play_arrow),
+                      //         onPressed: () {
+                      //           // Handle play episode
+                      //         },
+                      //       ),
+                      //       IconButton(
+                      //         icon: Icon(
+                      //           episode.isDownloaded
+                      //               ? Icons.download_done
+                      //               : Icons.download,
+                      //         ),
+                      //         onPressed: () {
+                      //           setState(() {
+                      //             episode.isDownloaded = !episode.isDownloaded;
+                      //           });
+                      //         },
+                      //       ),
+                      //     ],
+                      //   ),
+                      // ),
+                    ),
+                  )
+                  .toList(),
+            ),
+    );
+  }
+}

--- a/lib/feature/view/podcast_details_screen.dart
+++ b/lib/feature/view/podcast_details_screen.dart
@@ -25,12 +25,10 @@ class PodcastDetailsScreenState extends State<PodcastDetailsScreen> {
   Map<String, dynamic>? _podcastDetails;
   bool _isLoading = true;
   bool _isDescriptionExpanded = false;
-  User? _currentUser;
 
   @override
   void initState() {
     super.initState();
-    _currentUser = _auth.currentUser;
     _fetchPodcastDetails();
   }
 

--- a/lib/feature/view/podcast_details_screen.dart
+++ b/lib/feature/view/podcast_details_screen.dart
@@ -82,7 +82,7 @@ class PodcastDetailsScreenState extends State<PodcastDetailsScreen> {
                             itemCount: _podcastDetails!['episodes']['items'].length,
                             itemBuilder: (context, index) {
                               final episode = _podcastDetails!['episodes']['items'][index];
-                              return EpisodeTile(episode: Episode.fromJson(episode), backupImageUrl: widget.podcast['image_url'], onToggleInPlaylist: _toggleInPlaylist);
+                              return EpisodeTile(episode: Episode.fromJson(episode['id'], episode), backupImageUrl: widget.podcast['image_url'], onToggleInPlaylist: _toggleInPlaylist);
                             },
                           )
                         : const Text('No episodes available'),
@@ -108,7 +108,7 @@ class PodcastDetailsScreenState extends State<PodcastDetailsScreen> {
 
     if (episode.isInPlaylist) {
       await playlistRef.set({
-        'title': episode.title,
+        'title': episode.name,
       });
     } else {
       await playlistRef.delete();

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 
 import 'package:podcast/feature/search/podcast_search_screen.dart';
 import 'package:podcast/feature/view/latest_episodes_screen.dart';
+import 'package:podcast/feature/view/playlist_screen.dart';
 import 'package:podcast/feature/view/view_subscription_screen.dart';
 import 'package:podcast/login_screen.dart';
 
@@ -67,6 +68,16 @@ class HomeScreen extends StatelessWidget {
                 );
               },
               child: const Text('Latest episodes'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const PlaylistScreen()),
+                );
+              },
+              child: const Text('Playlist'),
             ),
           ],
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -246,6 +246,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      sha256: "2c5611c0b44e20d180e4342318e1bbc28b0a44ad2c442f5df16962606fd3e8e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   http: ^1.2.2
   flutter_dotenv: ^5.2.1
   firebase_remote_config: ^5.1.3
+  flutter_slidable: ^3.1.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Fixes https://github.com/mvfavila/podcast/issues/61

# Changes

- Load Playlist: Fetches the playlist episodes from Firebase Firestore.
- Filter Completed Episodes: Only shows episodes that are not marked as “played.”
- Reorder Playlist: Allows dragging and reordering episodes in the playlist.
- Context Menu: Drag to the left shows options to remove from the playlist and mark as played.
- Play and Download: Buttons to play or download episodes.